### PR TITLE
feat: use PSR-4 for classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,11 @@
     "friendsofphp/php-cs-fixer": "@stable",
     "getkirby/cms": "^3.9"
   },
+  "autoload": {
+    "psr-4": {
+        "JohannSchopplich\\Headless\\": "src/classes/"
+    }
+  },
   "scripts": {
     "fix": "php-cs-fixer fix",
     "dist": "composer install --no-dev --optimize-autoloader"


### PR DESCRIPTION
this is needed or one can not use the classes to create custom routes before the plugin was loaded. 

like the custom route example from your README in the main `site/config/config.php` does not work otherwise.